### PR TITLE
Changing the sample_rate of loaded audio file to 16000

### DIFF
--- a/enhancement.py
+++ b/enhancement.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from os.path import join
 
 import torch
+import torchaudio
 from soundfile import write
 from torchaudio import load
 from tqdm import tqdm
@@ -45,7 +46,8 @@ if __name__ == '__main__':
         filename = noisy_file.split('/')[-1]
         
         # Load wav
-        y, _ = load(noisy_file) 
+        y, loading_sr = load(noisy_file)
+        y = torchaudio.functional.resample(y, orig_freq=loading_sr, new_freq=sr)
         T_orig = y.size(1)   
 
         # Normalize


### PR DESCRIPTION
Hi,
This pull request adds a line of code to resample the audio after loading it to prevent audio stretching. The original audio was loaded at a sample rate of 48000Hz, but to maintain consistency with the rest of the codebase, it is now resampled to 16000Hz using the `torchaudio.functional.resample` function. 
This change was necessary because the mismatch between the sample rates during loading and processing was causing the audio to stretch, leading to a difference in length of up to 3 times the original audio. By resampling the audio, this pull request ensures that the audio remains at its original length, improving the accuracy of any downstream processing.